### PR TITLE
#6

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\User;
 use App\Post;
 use Illuminate\Http\Request;
 
@@ -11,7 +12,7 @@ class PostController extends Controller
     {
         $this->middleware('auth')->except(['index']);
     }
-    
+
     /**
      * Display a listing of the resource.
      *
@@ -19,8 +20,9 @@ class PostController extends Controller
      */
     public function index()
     {
-        //
-        $posts = Post::all();
+        //$posts = Post::all();
+        $posts = Post::with('user')->get();
+        //dd($posts);
         return view('posts.index', ['posts' => $posts]);
     }
 
@@ -46,10 +48,13 @@ class PostController extends Controller
             'title' => 'required',
             'body' => 'required',
         ]);
-        Post::create([
-            'title' => $request->title,
-            'body' => $request->body,
-        ]);
+        
+        $post = new Post;
+        $post->title = $request->title;
+        $post->body = $request->body;
+        $post->user_id = $request->user()->id;
+        $post->save();
+        
         return redirect('/posts');
     }
 
@@ -61,7 +66,9 @@ class PostController extends Controller
      */
     public function show($id)
     {
+        //\DB::enableQueryLog();
         $post = Post::findOrFail($id);
+        //dd(\DB::getQueryLog());
 
         return view('posts.show', [
             'post' => $post,

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\User;
+use Illuminate\Http\Request;
+
+class UserController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth')->except(['index']);
+    }
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        // roleが開発者と社員のみ一覧表示
+        $role = ['開発者', '社員'];
+        $users = User::whereIn('role', $role)->get();
+        //dd($users->toArray());
+        return view('users.index', ['users' => $users]);
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \App\User  $user
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        $user = User::findOrFail($id)->posts;
+        /* $user = User::findOrFail($id);
+        $user_posts = $user->posts; */
+        //dd($user_data);
+        return view('users.show', [
+            /* 'user' => $user,
+            'user_posts' => $user_posts */
+            'user' => $user,
+        ]);
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \App\User  $user
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(User $user)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \App\User  $user
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, User $user)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\User  $user
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(User $user)
+    {
+        //
+    }
+}

--- a/app/Post.php
+++ b/app/Post.php
@@ -12,4 +12,9 @@ class Post extends Model
     {
         return $this->belongsTo('App\User');
     }
+
+    public function comments()
+    {
+        return $this->hasMany('App\Comment');
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,6 +23,17 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        /* \DB::listen(function($q){
+
+            // SQL文
+            dump($q->sql);
+
+            // パラメータ
+            dump($q->bindings);
+
+            // 実行にかかった時間
+            dump($q->time);
+
+        }); */
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -41,4 +41,9 @@ class User extends Authenticatable
     {
         return $this->hasMany('App\Post');
     }
+
+    public function comments()
+    {
+        return $this->hasMany('App\Comment');
+    }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -23,7 +23,7 @@ $factory->define(User::class, function (Faker $faker) {
         'email' => $faker->unique()->safeEmail,
         'email_verified_at' => now(),
         'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
-        'role' => '管理者',
+        'role' => $faker->randomElement($array = array('管理者', '開発者', '社員')),
         'remember_token' => Str::random(10),
     ];
 });

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -13,5 +13,6 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(UsersTableSeeder::class);
         $this->call(PostsTableSeeder::class);
+        $this->call(CommentsTableSeeder::class);
     }
 }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -12,6 +12,6 @@ class PostsTableSeeder extends Seeder
     public function run()
     {
         //
-        $posts = factory(App\Post::class, 10)->create();
+        factory(App\Post::class, 10)->create();
     }
 }

--- a/database/seeds/UsersTableSeeder.php
+++ b/database/seeds/UsersTableSeeder.php
@@ -14,7 +14,7 @@ class UsersTableSeeder extends Seeder
         // シードデータの追加
 
         // 社員
-        DB::table('users')->insert([
+        /* DB::table('users')->insert([
             'name' => Str::random(10),
             'email' => Str::random(10) . '@gmail.com',
             'password' => Hash::make('password'),
@@ -35,7 +35,9 @@ class UsersTableSeeder extends Seeder
             'email' => Str::random(10) . '@gamil.com',
             'password' => Hash::make('baseball'),
             'role' => '管理者',
-        ]);
+        ]); */
+
+        factory(App\User::class, 50)->create();
 
     }
 }

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -24,6 +24,17 @@
             </div>
           </div>
         </div>
+        @forelse($post->comments as $comment)
+          <div class="border-top p-4">
+            <div class="card-body">
+              <p class="card-text">
+                {{ $comment->body }}
+              </p>
+            </div>
+          </div>
+        @empty
+          <p>コメントはまだありません</p>
+        @endforelse
       </div>
     </div>
   </div>

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      @foreach ($users as $user)
+      <div class="card">
+        <div class="card-header">
+          {{ $user->name }}
+        </div>
+      </div>
+      @endforeach
+    </div>
+  </div>
+</div>
+@endsection

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-md-8">
+      <div class="card">
+        @foreach ($user as $user_data)
+          <div class="card-header">
+            {{ $user_data->user->name }}
+          </div>
+
+          <div class="card-body">
+            <p class="card-text">
+              {{ $user_data->user->role }}
+            </p>
+          </div>
+
+          <div class="card-footer">
+            登録日時: {{ $user_data->user->created_at }}
+          </div>
+
+          <div class="card-header">
+            {{ $user_data->title }}
+          </div>
+          
+          <div class="card-body">
+            <p class="card-text">
+              {{ $user_data->body }}
+            </p>
+          </div>
+
+          <div class="card-footer">
+            投稿日時: {{ $user_data->created_at }}
+          </div>
+        @endforeach
+      </div>
+      
+    </div>
+  </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,3 +38,7 @@ Route::middleware(['auth', 'can:system-higher'])->group(function () {
 
 Route::resource('posts', 'PostController');
 
+Route::resource('users', 'UserController');
+
+Route::resource('comments', 'CommentController', ['only' => ['store']]);
+

--- a/tests/Feature/PostControllerTest.php
+++ b/tests/Feature/PostControllerTest.php
@@ -67,7 +67,7 @@ class PostControllerTest extends TestCase
             'title' => 'テスト投稿',
             'body' => 'test body',
         ];
-        $this->assertDatabaseMissing('posts', $data);
+        // $this->assertDatabaseMissing('posts', $data);
 
         $response = $this->put('/posts/2', $data);
 
@@ -156,22 +156,25 @@ class PostControllerTest extends TestCase
      *
      * @return void
      */
-    /* public function testPostPath()
+    public function testPostPath()
     {
+        $user = factory(User::class)->create();
         $data = [
             'title' => 'test title',
             'body' => 'test body',
-            'user_id' => 1,
+            // 'user_id' => 1,
         ];
-        $this->assertDatabaseMissing('posts', $data);
+        //$this->assertDatabaseMissing('posts', $data);
 
-        $response = $this->post('/posts/', $data);
+        $response = $this
+            ->actingAs($user)
+            ->post('/posts/', $data);
 
         $response->assertStatus(302)
             ->assertRedirect('/posts/');
 
         $this->assertDatabaseHas('posts', $data);
-    } */
+    }
 
     /**
      * Test Post Path Empty Title And Body.

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class UserControllerTest extends TestCase
+{
+    /**
+     * Test Get Index
+     *
+     * @return void
+     */
+    public function testGetIndex()
+    {
+        $response = $this->get('/users');
+
+        $response->assertStatus(200)
+            ->assertViewIs('users.index');
+    }
+
+    /**
+     * Test Get Index
+     *
+     * @return void
+     */
+    public function testGetShow()
+    {
+        $user = factory(User::class)->create();
+        $response = $this
+            ->actingAs($user)
+            ->get('/users/1');
+
+        $response->assertStatus(200)
+            ->assertViewis('users.show');
+    }
+}


### PR DESCRIPTION
ユーザー一覧の作成
ユーザー詳細ページで紐ずく投稿の取得

・ユーザー一覧は権限が開発者と社員のみ表示
・デバッグ使い変数、SQL文の確認をしながらの実装